### PR TITLE
SeAT Discourse SSO - Integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "laravel",
         "library",
         "single sign on",
-        "spinen",
         "sso",
         "seat"
     ],
@@ -22,16 +21,14 @@
         "php": ">=5.5.9",
         "cviebrock/discourse-php": "^0.9.3",
         "illuminate/routing": "5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*",
-        "richp10/discourse-api-php": "^1.2"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.1",
         "phpunit/phpunit": "~4.0|~5.0",
         "psy/psysh": "^0.5.1",
         "satooshi/php-coveralls": "^0.6.1|^1",
-        "symfony/var-dumper": "~2.7|~3.0",
-        "richp10/discourse-api-php": "^1.2"
+        "symfony/var-dumper": "~2.7|~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,24 +18,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.1",
         "cviebrock/discourse-php": "^0.9.3",
-        "illuminate/routing": "5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*"
-    },
-    "require-dev": {
-        "mockery/mockery": "^0.9.1",
-        "phpunit/phpunit": "~4.0|~5.0",
-        "psy/psysh": "^0.5.1",
-        "satooshi/php-coveralls": "^0.6.1|^1",
-        "symfony/var-dumper": "~2.7|~3.0"
+        "laravel/framework": "5.5.*",
+        "eveseat/web": "3.0.*"
     },
     "autoload": {
-        "psr-4": {
-            "Herpaderpaldent\\Seat\\SeatDiscourse\\": "src/"
-        }
-    },
-    "autoload-dev": {
         "psr-4": {
             "Herpaderpaldent\\Seat\\SeatDiscourse\\": "src/"
         }
@@ -47,9 +35,6 @@
             ]
         }
     },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
+    "minimum-stability": "alpha",
     "prefer-stable": true
 }

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,9 @@ topics based on roles in SeAT.
 
 ## Prerequisite
 
-There are two dependencies.
+There are is one dependency.
 
 * ["cviebrock/discourse-php": "^0.9.3"](https://github.com/cviebrock/discourse-php)
-* ["richp10/discourse-api-php": "^1.2"](https://github.com/richp10/discourse-api-php)
 
 ## Install
 
@@ -17,6 +16,19 @@ Install Discourse SSO for Laravel:
 
 ```bash
     $ composer require herpaderpaldent/seat-discourse
+```
+
+add following to the `.env`:
+
+
+
+* DISCOURSE_URL (do not add a trailing slash!)
+* DISCOURSE_API_USERNAME the username of the admin account you generated the API key with
+* DISCOURSE_API_KEY the key you just generated
+```
+DISCOURSE_URL=https://discourse.example.com
+DISCOURSE_API_USERNAME=username
+DISCOURSE_API_KEY=key
 ```
 
 ### For SeAT 3.0, you are done with the Install
@@ -33,3 +45,5 @@ The package uses the auto registration feature
 * support for [`custom_fields`](https://meta.discourse.org/t/custom-user-fields-for-plugins/14956)
 * failed login redirect
 * `return_paths` support
+
+#

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,7 @@
 # Hepraderp Aldent's - SeAT Discourse
 
 This SeAT-Package is based upon [SPINEN's Discourse SSO for Laravel](https://github.com/spinen/laravel-discourse-sso). 
-Extendend with [richp10/discourse-api-php](https://github.com/richp10/discourse-api-php) to be able to create users and 
-topics based on roles in SeAT.
+Extendend with custom actions to create groups.
 
 ## Prerequisite
 
@@ -31,7 +30,8 @@ DISCOURSE_API_USERNAME=username
 DISCOURSE_API_KEY=key
 DISCOURSE_SECRET=secret
 ```
-Discourse-URL {{base_url}}/discourse/sso
+On the discourse-page settings set the URL accordingly: 
+Discourse-URL: `{{base_url}}/discourse/sso`
 
 ### For SeAT 3.0, you are done with the Install
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,9 @@ add following to the `.env`:
 DISCOURSE_URL=https://discourse.example.com
 DISCOURSE_API_USERNAME=username
 DISCOURSE_API_KEY=key
+DISCOURSE_SECRET=secret
 ```
+Discourse-URL {{base_url}}/discourse/sso
 
 ### For SeAT 3.0, you are done with the Install
 
@@ -41,9 +43,5 @@ The package uses the auto registration feature
 
 * document Discourse configuration
 * send `log out` to Discourse when disabling/deleting the user
-* badges to user
-* support for [`custom_fields`](https://meta.discourse.org/t/custom-user-fields-for-plugins/14956)
 * failed login redirect
-* `return_paths` support
 
-#

--- a/src/Action/Discourse/Groups/Attach.php
+++ b/src/Action/Discourse/Groups/Attach.php
@@ -23,14 +23,21 @@ class Attach
     public function execute(Collection $roles, Collection $groups)
     {
         try{
-            $rolenames = $roles->map(function($role) {return $role->title;});
-            $groupnames = $groups->map( function ($group){return $group->name;});
+            $feedback = collect();
 
-            $rolenames->diff($groupnames)->each(function($missingroup) {
-                $this->create->execute($missingroup);
+
+            $groupnames_array = $groups->map( function ($group){return $group->name;})->toArray();
+
+            $roles->each(function($role) use ($feedback, $groupnames_array){
+                if(!in_array(studly_case($role->title),$groupnames_array)){
+                    $feedback->push( $this->create->execute(studly_case($role->title)));
+                }
             });
 
-            return 'Created groups: '. $rolenames->diff($groupnames);
+
+            return $feedback;
+
+
 
         } catch (Exception $e){
             return $e;

--- a/src/Action/Discourse/Groups/Attach.php
+++ b/src/Action/Discourse/Groups/Attach.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 05.06.18
+ * Time: 18:01
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+
+use Illuminate\Support\Collection;
+
+class Attach
+{
+    protected $create;
+
+    public function __construct(Create $create)
+    {
+        $this->create = $create;
+    }
+
+    public function execute(Collection $roles, Collection $groups)
+    {
+        try{
+            $rolenames = $roles->map(function($role) {return $role->title;});
+            $groupnames = $groups->map( function ($group){return $group->name;});
+
+            $rolenames->diff($groupnames)->each(function($missingroup) {
+                $this->create->execute($missingroup);
+            });
+
+            return 'Created groups: '. $rolenames->diff($groupnames);
+
+        } catch (Exception $e){
+            return $e;
+        }
+
+    }
+
+}

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 05.06.18
+ * Time: 16:01
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
+
+
+class Create
+{
+    public function execute(String $groupname)
+    {
+        $client = new Client();
+        try {
+            $response = $client->request('POST', getenv('DISCOURSE_URL').'/admin/groups', [
+                'form_params' => [
+                    'api_key' => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'group[name]' => $groupname
+                ],
+            ]);
+
+            if (200 === $response->getStatusCode()) {
+
+                return true;
+
+            }
+
+            abort(500,"Something went wrong at /admin/groups");
+        } catch (GuzzleException $e) {
+            return $e;
+
+        }
+
+
+
+    }
+
+}

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -11,7 +11,6 @@ namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Client;
 
-
 class Create
 {
     public function execute(String $groupname)
@@ -28,7 +27,7 @@ class Create
 
             if (200 === $response->getStatusCode()) {
 
-                return true;
+                return 'Created Group: '. $groupname;
 
             }
 

--- a/src/Action/Discourse/Groups/Delete.php
+++ b/src/Action/Discourse/Groups/Delete.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 05.06.18
+ * Time: 18:44
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
+
+
+class Delete
+{
+    public function execute(int $group_id)
+    {
+
+        $client = new Client();
+        try {
+            $response = $client->request('DELETE', getenv('DISCOURSE_URL') . '/admin/groups/' . $group_id . '.json', [
+                'form_params' => [
+                    'api_key'      => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME')
+                ],
+            ]);
+
+            if (200 === $response->getStatusCode()) {
+
+                return "success";
+
+            }
+
+            abort(500, "Something went wrong at deleting group");
+        } catch (GuzzleException $e) {
+            return $e;
+
+        }
+
+
+    }
+}

--- a/src/Action/Discourse/Groups/Detach.php
+++ b/src/Action/Discourse/Groups/Detach.php
@@ -24,7 +24,7 @@ class Detach
     public function execute(Collection $roles, Collection $groups)
     {
         try{
-            $rolenames_array = $roles->map(function($role) {return $role->title;})->toArray();
+            $rolenames_array = $roles->map(function($role) {return studly_case($role->title);})->toArray();
 
             //Group minus Roles, what is left should be deleted
             $groups_deleted = collect();

--- a/src/Action/Discourse/Groups/Detach.php
+++ b/src/Action/Discourse/Groups/Detach.php
@@ -27,16 +27,17 @@ class Detach
             $rolenames_array = $roles->map(function($role) {return $role->title;})->toArray();
 
             //Group minus Roles, what is left should be deleted
-            $groups->each(function ($group) use ($rolenames_array) {
+            $groups_deleted = collect();
+            $groups->each(function ($group) use ($rolenames_array,$groups_deleted) {
                 if(!in_array($group->name, $rolenames_array) ){
+                    $groups_deleted->push($group->name);
                     $this->delete->execute($group->id);
                 };
             });
 
-            $groupnames = $groups->map( function ($group) {return $group->name;});
-            $rolenames = $roles->map(function($role) {return $role->title;});
 
-            return "Groups deleted " . $rolenames->diff($groupnames);
+
+            return "Groups deleted " . $groups_deleted;
 
 
         } catch (Exception $e){

--- a/src/Action/Discourse/Groups/Detach.php
+++ b/src/Action/Discourse/Groups/Detach.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 05.06.18
+ * Time: 18:56
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+
+use Illuminate\Support\Collection;
+
+
+class Detach
+{
+    protected $delete;
+
+    public function __construct(Delete $delete)
+    {
+        $this->delete = $delete;
+    }
+
+    public function execute(Collection $roles, Collection $groups)
+    {
+        try{
+            $rolenames_array = $roles->map(function($role) {return $role->title;})->toArray();
+
+            //Group minus Roles, what is left should be deleted
+            $groups->each(function ($group) use ($rolenames_array) {
+                if(!in_array($group->name, $rolenames_array) ){
+                    $this->delete->execute($group->id);
+                };
+            });
+
+            $groupnames = $groups->map( function ($group) {return $group->name;});
+            $rolenames = $roles->map(function($role) {return $role->title;});
+
+            return "Groups deleted " . $rolenames->diff($groupnames);
+
+
+        } catch (Exception $e){
+            return $e;
+        }
+
+    }
+
+}

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -27,19 +27,10 @@ class Get
                 return $item->automatic;
             });
 
-            /*$filtered = $current_groups->reject(function ($item){
-            return $item['automatic'];
-        });*/
-            $test = $response->getBody();
-
-            //return json_decode($test);
             return $body;
         } catch (GuzzleException $e) {
             return $e;
-
         }
-
-
 
     }
 

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 05.06.18
+ * Time: 13:13
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
+
+class Get
+{
+    public function execute()
+    {
+        $client = new Client();
+        try {
+            $response = $client->request('GET', getenv('DISCOURSE_URL').'/groups/search.json', [
+                'query' => [
+                    'api_key' => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME')
+                    ],
+            ]);
+            $body = collect(json_decode($response->getBody()))->reject(function ($item){
+                return $item->automatic;
+            });
+
+            /*$filtered = $current_groups->reject(function ($item){
+            return $item['automatic'];
+        });*/
+            $test = $response->getBody();
+
+            //return json_decode($test);
+            return $body;
+        } catch (GuzzleException $e) {
+            return $e;
+
+        }
+
+
+
+    }
+
+}

--- a/src/Action/Discourse/Groups/Sync.php
+++ b/src/Action/Discourse/Groups/Sync.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *  * User: Herpaderp Aldent
+ * Date: 09.06.2018
+ * Time: 10:48
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups;
+
+
+use Seat\Web\Models\Acl\Role;
+
+class Sync
+{
+    protected $attach;
+    protected $detach;
+    protected $get;
+
+    public function __construct(Attach $attach, Detach $detach, Get $get)
+    {
+        $this->attach = $attach;
+        $this->detach = $detach;
+        $this->get = $get;
+    }
+
+    public function execute()
+    {
+        $roles = Role::all();
+        $groups = $this->get->execute();
+
+        $feedback = collect();
+
+
+        if($roles->map(function($role) {return $role->title;})->diff($groups->map( function ($group){return $group->name;}))->isNotEmpty())
+        {
+            $feedback->push($this->attach->execute($roles,$groups));
+        }
+
+        if($groups->map(function($group) {return $group->name;})->diff($roles->map( function ($role){return studly_case($role->title);}))->isNotEmpty()){
+            $feedback->push($this->detach->execute($roles,$groups));
+        }
+
+        return $feedback;
+    }
+
+}

--- a/src/Action/Discourse/Users/Create.php
+++ b/src/Action/Discourse/Users/Create.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 06.06.18
+ * Time: 16:53
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
+use Seat\Web\Models\Group;
+
+
+class Create
+{
+    public function execute(Group $group)
+    {
+
+        $client = new Client();
+        try {
+            $response = $client->request('POST', getenv('DISCOURSE_URL') . '/users.json', [
+                'form_params' => [
+                    'api_key'      => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'name'  => $group->main_character->name,
+                    'email' => $group->email,
+                    'password' => md5(microtime()),
+                    'username' => studly_case($group->main_character->name),
+                    'active' => true,
+                    'approved' => true
+                ],
+            ]);
+
+            if (200 === $response->getStatusCode()) {
+
+                return "User " . studly_case($group->main_character->name) . " successfully created." ;
+
+            }
+
+            abort(500, "Something went wrong at creating user");
+        } catch (GuzzleException $e) {
+            return $e;
+
+        }
+
+
+    }
+}

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -6,11 +6,34 @@
  * Time: 09:04
  */
 
-namespace src\Action\Discourse\Users;
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
 
 
 class ListUsers
 {
 // {{base_url}}/admin/users/list/active.json?api_key={{api_key}}&api_username={{api_username}}&order=topics_entered
 // show_emails=true
+
+    public function execute()
+    {
+        $client = new Client();
+        try {
+            $response = $client->request('GET', getenv('DISCOURSE_URL').'/admin/users/list/active.json', [
+                'query' => [
+                    'api_key' => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'order' => 'topics_entered',
+                    'show_emails' => 'true'
+                ],
+            ]);
+
+            return collect(json_decode($response->getBody()));
+        } catch (GuzzleException $e) {
+            return $e;
+        }
+
+    }
 }

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 07.06.18
+ * Time: 09:04
+ */
+
+namespace src\Action\Discourse\Users;
+
+
+class ListUsers
+{
+// {{base_url}}/admin/users/list/active.json?api_key={{api_key}}&api_username={{api_username}}&order=topics_entered
+// show_emails=true
+}

--- a/src/Action/Seat/Groups/Sync.php
+++ b/src/Action/Seat/Groups/Sync.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fehu
+ * Date: 07.06.18
+ * Time: 15:34
+ */
+
+namespace Herpaderpaldent\Seat\SeatDiscourse\Action\Seat\Groups;
+
+
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\ListUsers;
+use Seat\Web\Models\Group;
+
+class Sync
+{
+
+    protected $list_users;
+
+    public function __construct(ListUsers $list_users)
+    {
+        $this->list_users = $list_users;
+    }
+
+    public function execute(Group $group)
+    {
+
+        if($group->email)
+        {
+
+            if(! in_array($group->email,$this->list_users->execute()->map(function ($item){return $item->email;})->toArray()))
+            {
+                return "mail exists";
+            }
+            return "Discourse User already exists for Group";
+            //$this->info($create->execute(Group::find(3)));
+            //$this->info(studly_case(Group::find(2)->main_character->name));
+        }
+    }
+
+}

--- a/src/Commands/SyncRolesWithDiscourse.php
+++ b/src/Commands/SyncRolesWithDiscourse.php
@@ -8,13 +8,13 @@
 
 namespace Herpaderpaldent\Seat\SeatDiscourse\Commands;
 
-
-use function foo\func;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Attach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Detach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Get;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\Create;
 use Illuminate\Console\Command;
 use Seat\Web\Models\Acl\Role;
+use Seat\Web\Models\Group;
 
 class SyncRolesWithDiscourse extends Command
 {
@@ -26,11 +26,20 @@ class SyncRolesWithDiscourse extends Command
         parent::__construct();
     }
 
-    public function handle(Get $get, Attach $attach, Detach $detach)
+    public function handle(Get $get, Attach $attach, Detach $detach, Create $create)
     {
 
-        $this->info($attach->execute(Role::all(),$get->execute()));
-        $this->info($detach->execute(Role::all(),$get->execute()));
+        //return $get->execute();
+        //$this->info($attach->execute(Role::all(),$get->execute()));
+        //$this->info($detach->execute(Role::all(),$get->execute()));
+
+        if(Group::find(3)->email)
+        {
+            $this->info($create->execute(Group::find(3)));
+           //$this->info(studly_case(Group::find(2)->main_character->name));
+        }
+
+
 
 
     }

--- a/src/Commands/SyncRolesWithDiscourse.php
+++ b/src/Commands/SyncRolesWithDiscourse.php
@@ -9,11 +9,16 @@
 namespace Herpaderpaldent\Seat\SeatDiscourse\Commands;
 
 
+use function foo\func;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Attach;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Detach;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Get;
 use Illuminate\Console\Command;
+use Seat\Web\Models\Acl\Role;
 
 class SyncRolesWithDiscourse extends Command
 {
-    protected $signature = 'seat-groups:users:update';
+    protected $signature = 'seat-discourse:roles:sync';
     protected $description = 'This command creates Discourse Groups according to the Roles in SeAT';
 
     public function __construct()
@@ -21,8 +26,12 @@ class SyncRolesWithDiscourse extends Command
         parent::__construct();
     }
 
-    public function handle()
+    public function handle(Get $get, Attach $attach, Detach $detach)
     {
+
+        $this->info($attach->execute(Role::all(),$get->execute()));
+        $this->info($detach->execute(Role::all(),$get->execute()));
+
 
     }
 }

--- a/src/Commands/SyncRolesWithDiscourse.php
+++ b/src/Commands/SyncRolesWithDiscourse.php
@@ -11,9 +11,9 @@ namespace Herpaderpaldent\Seat\SeatDiscourse\Commands;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Attach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Detach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Get;
-use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\Create;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Sync;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Create;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\ListUsers;
-use Herpaderpaldent\Seat\SeatDiscourse\Action\Seat\Groups\Sync;
 use Illuminate\Console\Command;
 use Seat\Web\Models\Acl\Role;
 use Seat\Web\Models\Group;
@@ -28,12 +28,12 @@ class SyncRolesWithDiscourse extends Command
         parent::__construct();
     }
 
-    public function handle(Get $get, Attach $attach, Detach $detach, Create $create, ListUsers $list_users, Sync $sync)
+    public function handle(Get $get, Attach $attach, Detach $detach, Create $create, ListUsers $list_users, Sync $sync )
     {
-
         //return $get->execute();
         //$this->info($attach->execute(Role::all(),$get->execute()));
         //$this->info($detach->execute(Role::all(),$get->execute()));
+        //$this->info($create->execute('test'));
 
         /*if(Group::find(3)->email)
         {
@@ -41,8 +41,11 @@ class SyncRolesWithDiscourse extends Command
            //$this->info(studly_case(Group::find(2)->main_character->name));
         }*/
 
-        $this->info($list_users->execute()->map(function ($item){return $item->email;}));
-        $this->info($sync->execute(Group::find(2)));
+        $this->info($sync->execute());
+
+        //return Role::all()->map(function($role) {return $role->title;})->diff($get->execute()->map( function ($group){return $group->name;}));
+
+
 
 
 

--- a/src/Commands/SyncRolesWithDiscourse.php
+++ b/src/Commands/SyncRolesWithDiscourse.php
@@ -12,6 +12,8 @@ use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Attach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Detach;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Groups\Get;
 use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\Create;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Discourse\Users\ListUsers;
+use Herpaderpaldent\Seat\SeatDiscourse\Action\Seat\Groups\Sync;
 use Illuminate\Console\Command;
 use Seat\Web\Models\Acl\Role;
 use Seat\Web\Models\Group;
@@ -26,18 +28,21 @@ class SyncRolesWithDiscourse extends Command
         parent::__construct();
     }
 
-    public function handle(Get $get, Attach $attach, Detach $detach, Create $create)
+    public function handle(Get $get, Attach $attach, Detach $detach, Create $create, ListUsers $list_users, Sync $sync)
     {
 
         //return $get->execute();
         //$this->info($attach->execute(Role::all(),$get->execute()));
         //$this->info($detach->execute(Role::all(),$get->execute()));
 
-        if(Group::find(3)->email)
+        /*if(Group::find(3)->email)
         {
             $this->info($create->execute(Group::find(3)));
            //$this->info(studly_case(Group::find(2)->main_character->name));
-        }
+        }*/
+
+        $this->info($list_users->execute()->map(function ($item){return $item->email;}));
+        $this->info($sync->execute(Group::find(2)));
 
 
 

--- a/src/Events/Register.php
+++ b/src/Events/Register.php
@@ -17,49 +17,9 @@ require_once DiscourseAPI;
 class Register
 {
 
-
-
     public static function handle(RegisterEvent $event)
     {
 
-        //First Update Roles
-        //Secound Create User
-
-        $api = new DiscourseAPI(parse_url(
-            getenv('DISCOURSE_URL'),PHP_URL_HOST),
-            getenv('DISCOURSE_API_KEY'),
-            parse_url(getenv('DISCOURSE_URL'),PHP_URL_SCHEME));
-
-        // create user
-        $r = $api->createUser(
-            $event->user->name,
-            $event->user->name,
-            $event->user->email,
-            $event->user->character_owner_hash
-            );
-        print_r($r);
-
-        // in order to activate we need the id
-        $r = $api->getUserByUsername($event->user->name);
-        print_r($r);
-
-        // activate the user
-        $r = $api->activateUser($r->apiresult->user->id);
-        print_r($r);
-
-
-
-        /*
-
-        $event->user->login_history()->save(new UserLoginHistory([
-            'source'     => Request::getClientIp(),
-            'user_agent' => Request::header('User-Agent'),
-            'action'     => 'logout',
-        ]));
-
-        $message = 'User logged out from ' . Request::getClientIp();
-        event('security.log', [$message, 'authentication']);
-        */
     }
 
 

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -16,15 +16,9 @@ Route::group([
             'uses' => 'SsoController@login',
             'as'   => 'sso.login',
         ]);
+        Route::get('discourse', [
+            'uses' => 'SsoController@redirect',
+            'as'   => 'sso.forum',
+        ]);
     });
 });
-
-/*
- * ToDo: Delete this if working
- * $this->app['router']->group(["middleware" => ["web", "auth"]], function (Router $router) {
-            $router->get($this->app['config']->get('services.discourse.route'), [
-                'uses' => 'Herpaderpaldent\Seat\SeatDiscourse\Controllers\SsoController@login',
-                'as'   => 'sso.login',
-            ]);
-        });
- */

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *  * User: Herpaderp Aldent
+ * Date: 08.06.2018
+ * Time: 22:14
+ */
+
+Route::group([
+    'namespace' => 'Herpaderpaldent\Seat\SeatDiscourse\Http\Controllers'
+], function (){
+    Route::group([
+        'middleware' => ['web', 'auth']
+    ], function (){
+        Route::get('discourse/sso', [
+            'uses' => 'SsoController@login',
+            'as'   => 'sso.login',
+        ]);
+    });
+});
+
+/*
+ * ToDo: Delete this if working
+ * $this->app['router']->group(["middleware" => ["web", "auth"]], function (Router $router) {
+            $router->get($this->app['config']->get('services.discourse.route'), [
+                'uses' => 'Herpaderpaldent\Seat\SeatDiscourse\Controllers\SsoController@login',
+                'as'   => 'sso.login',
+            ]);
+        });
+ */

--- a/src/SeatDiscourseServiceProvider.php
+++ b/src/SeatDiscourseServiceProvider.php
@@ -19,14 +19,9 @@ class SeatDiscourseServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->addCommands();
+        $this->addRoutes();
         $this->addEvents();
 
-        $this->app['router']->group(["middleware" => ["web", "auth"]], function (Router $router) {
-            $router->get($this->app['config']->get('services.discourse.route'), [
-                'uses' => 'Herpaderpaldent\Seat\SeatDiscourse\Controllers\SsoController@login',
-                'as'   => 'sso.login',
-            ]);
-        });
     }
 
     /**
@@ -39,14 +34,14 @@ class SeatDiscourseServiceProvider extends ServiceProvider
         //
     }
 
-    public function addEvents()
+    private function addEvents()
     {
 
         // Internal Authentication Events
         //$this->app->events->listen(RegisterEvent::class, Register::class);
 
     }
-    public function addCommands()
+    private function addCommands()
     {
 
         $this->commands([
@@ -54,5 +49,11 @@ class SeatDiscourseServiceProvider extends ServiceProvider
         ]);
 
 
+    }
+    private function addRoutes()
+    {
+        if (!$this->app->routesAreCached()) {
+            include __DIR__ . '/Http/routes.php';
+        }
     }
 }

--- a/src/SeatDiscourseServiceProvider.php
+++ b/src/SeatDiscourseServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Herpaderpaldent\Seat\SeatDiscourse;
 
+use Herpaderpaldent\Seat\SeatDiscourse\Commands\SyncRolesWithDiscourse;
 use Herpaderpaldent\Seat\SeatDiscourse\Events\Register;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Routing\Registrar as Router;
@@ -42,14 +43,14 @@ class SeatDiscourseServiceProvider extends ServiceProvider
     {
 
         // Internal Authentication Events
-        $this->app->events->listen(RegisterEvent::class, Register::class);
+        //$this->app->events->listen(RegisterEvent::class, Register::class);
 
     }
     public function addCommands()
     {
 
         $this->commands([
-            //DiscourseGroupsUpdate::class,
+            SyncRolesWithDiscourse::class,
         ]);
 
 

--- a/src/SeatDiscourseServiceProvider.php
+++ b/src/SeatDiscourseServiceProvider.php
@@ -31,7 +31,8 @@ class SeatDiscourseServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/seatdiscourse.sidebar.php', 'package.sidebar');
     }
 
     private function addEvents()

--- a/src/config/seatdiscourse.sidebar.php
+++ b/src/config/seatdiscourse.sidebar.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *  * User: Herpaderp Aldent
+ * Date: 09.06.2018
+ * Time: 18:56
+ */
+
+return [
+    'seatdiscorse' => [
+        'name' => 'SeAT Discourse Forum',
+        'icon' => 'fa-comments-o',
+        'route_segment' => 'sso',
+        'route' => 'sso.forum'
+    ]
+];


### PR DESCRIPTION
Thanks to this package you can use SeAT as your SSO-Provider for Discourse-Forum (same forum as eve online uses). 
Roles are synced as groups to Discourse, with this you can limit who sees which categories on discourse forum.