### PR TITLE
Use HTTPS for avatar urls

### DIFF
--- a/src/Http/Controllers/SsoController.php
+++ b/src/Http/Controllers/SsoController.php
@@ -94,7 +94,7 @@ class SsoController extends Controller
             //'admin' => null,
 
             // Full path to user's avatar image
-            'avatar_url' => 'http://image.eveonline.com/Character/' . $this->user->group->main_character_id . '_128.jpg',
+            'avatar_url' => 'https://image.eveonline.com/Character/' . $this->user->group->main_character_id . '_128.jpg',
 
             // The avatar is cached, so this triggers an update
             'avatar_force_update' => true,


### PR DESCRIPTION
Otherwise avatars won't show up on ssl secured forums in modern browsers anymore.