### PR TITLE
Headers update

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,7 +3,6 @@ preset: laravel
 risky: false
 
 enabled:
-- alpha_ordered_imports
 - concat_with_spaces
 - no_empty_comment
 

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,7 +11,6 @@ disabled:
 - psr2_braces
 - phpdoc_no_package
 - concat_without_spaces
-- length_ordered_imports
 - no_blank_lines_after_class_opening
 - no_blank_lines_after_throw
 

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -8,7 +8,7 @@ enabled:
 - no_empty_comment
 
 disabled:
-- braces
+- psr2_braces
 - phpdoc_no_package
 - concat_without_spaces
 - length_ordered_imports

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -26,13 +26,13 @@ class Create
         try {
             $response = $client->request('POST', getenv('DISCOURSE_URL') . '/admin/groups', [
                 'form_params' => [
-                    'group[name]' => $groupnam
+                    'group[name]' => $groupname
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
                     'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
-            ]);,
+            ]);
 
             if (200 === $response->getStatusCode()) {
 

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -20,7 +20,7 @@ class Create
      * @return string
      * @throws \Herpaderpaldent\Seat\SeatDiscourse\Exceptions\DiscourseGuzzleException
      */
-    public function execute(String $groupname) : string
+    public function execute(String $groupname): string
     {
         $client = new Client();
         try {

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -29,8 +29,8 @@ class Create
                     'group[name]' => $groupname
                 ],
                 'headers' => [
-                    'api_key' => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-key' => getenv('DISCOURSE_API_KEY'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -26,13 +26,13 @@ class Create
         try {
             $response = $client->request('POST', getenv('DISCOURSE_URL') . '/admin/groups', [
                 'form_params' => [
-                    'group[name]' => $groupname
+                    'group[name]' => $groupname,
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
                     'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
-            ]);
+            ]);,
 
             if (200 === $response->getStatusCode()) {
 

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -20,7 +20,7 @@ class Create
      * @return string
      * @throws \Herpaderpaldent\Seat\SeatDiscourse\Exceptions\DiscourseGuzzleException
      */
-    public function execute(String $groupname): string
+    public function execute(string $groupname): string
     {
         $client = new Client();
         try {

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -26,11 +26,11 @@ class Create
         try {
             $response = $client->request('POST', getenv('DISCOURSE_URL') . '/admin/groups', [
                 'form_params' => [
-                    'group[name]' => $groupname
+                    'group[name]' => $groupname,
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME')
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -26,9 +26,11 @@ class Create
         try {
             $response = $client->request('POST', getenv('DISCOURSE_URL') . '/admin/groups', [
                 'form_params' => [
+                    'group[name]' => $groupname
+                ],
+                'headers' => [
                     'api_key' => getenv('DISCOURSE_API_KEY'),
                     'api_username' => getenv('DISCOURSE_API_USERNAME'),
-                    'group[name]' => $groupname,
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Create.php
+++ b/src/Action/Discourse/Groups/Create.php
@@ -26,11 +26,11 @@ class Create
         try {
             $response = $client->request('POST', getenv('DISCOURSE_URL') . '/admin/groups', [
                 'form_params' => [
-                    'group[name]' => $groupname,
+                    'group[name]' => $groupnam
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
             ]);,
 

--- a/src/Action/Discourse/Groups/Delete.php
+++ b/src/Action/Discourse/Groups/Delete.php
@@ -27,7 +27,7 @@ class Delete
             $response = $client->request('DELETE', getenv('DISCOURSE_URL') . '/admin/groups/' . $group_id . '.json', [
                 'headers' => [
                     'api-key'      => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME')
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Delete.php
+++ b/src/Action/Discourse/Groups/Delete.php
@@ -26,8 +26,8 @@ class Delete
         try {
             $response = $client->request('DELETE', getenv('DISCOURSE_URL') . '/admin/groups/' . $group_id . '.json', [
                 'headers' => [
-                    'api_key'      => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-key'      => getenv('DISCOURSE_API_KEY'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Delete.php
+++ b/src/Action/Discourse/Groups/Delete.php
@@ -25,7 +25,7 @@ class Delete
         $client = new Client();
         try {
             $response = $client->request('DELETE', getenv('DISCOURSE_URL') . '/admin/groups/' . $group_id . '.json', [
-                'form_params' => [
+                'headers' => [
                     'api_key'      => getenv('DISCOURSE_API_KEY'),
                     'api_username' => getenv('DISCOURSE_API_USERNAME'),
                 ],

--- a/src/Action/Discourse/Groups/Delete.php
+++ b/src/Action/Discourse/Groups/Delete.php
@@ -27,7 +27,7 @@ class Delete
             $response = $client->request('DELETE', getenv('DISCOURSE_URL') . '/admin/groups/' . $group_id . '.json', [
                 'headers' => [
                     'api-key'      => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -27,7 +27,7 @@ class Get
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/groups/search.json', [
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -26,8 +26,8 @@ class Get
         try {
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/groups/search.json', [
                 'headers' => [
-                    'api_key' => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-key' => getenv('DISCOURSE_API_KEY'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -27,7 +27,7 @@ class Get
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/groups/search.json', [
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME')
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -20,7 +20,7 @@ class Get
      * @return \Illuminate\Support\Collection
      * @throws \Herpaderpaldent\Seat\SeatDiscourse\Exceptions\DiscourseGuzzleException
      */
-    public function execute() : Collection
+    public function execute(): Collection
     {
         $client = new Client();
         try {

--- a/src/Action/Discourse/Groups/Get.php
+++ b/src/Action/Discourse/Groups/Get.php
@@ -25,10 +25,10 @@ class Get
         $client = new Client();
         try {
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/groups/search.json', [
-                'query' => [
+                'headers' => [
                     'api_key' => getenv('DISCOURSE_API_KEY'),
                     'api_username' => getenv('DISCOURSE_API_USERNAME'),
-                    ],
+                ],
             ]);
 
             if(! $response->getCode() === 200)

--- a/src/Action/Discourse/Users/GetUserByCharacterId.php
+++ b/src/Action/Discourse/Users/GetUserByCharacterId.php
@@ -18,7 +18,7 @@ class GetUserByCharacterId
         $client = new Client();
         try {
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/users/by-external/' . $id . '.json', [
-                'query' => [
+                'headers' => [
                     'api_key' => getenv('DISCOURSE_API_KEY'),
                     'api_username' => getenv('DISCOURSE_API_USERNAME'),
                 ],

--- a/src/Action/Discourse/Users/GetUserByCharacterId.php
+++ b/src/Action/Discourse/Users/GetUserByCharacterId.php
@@ -19,8 +19,8 @@ class GetUserByCharacterId
         try {
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/users/by-external/' . $id . '.json', [
                 'headers' => [
-                    'api_key' => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-key' => getenv('DISCOURSE_API_KEY'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/GetUserByCharacterId.php
+++ b/src/Action/Discourse/Users/GetUserByCharacterId.php
@@ -20,7 +20,7 @@ class GetUserByCharacterId
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/users/by-external/' . $id . '.json', [
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/GetUserByCharacterId.php
+++ b/src/Action/Discourse/Users/GetUserByCharacterId.php
@@ -20,7 +20,7 @@ class GetUserByCharacterId
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/users/by-external/' . $id . '.json', [
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME')
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -26,8 +26,8 @@ class ListUsers
                     'show_emails' => 'true',
                 ],
                 'headers' => [
-                    'api_key' => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-key' => getenv('DISCOURSE_API_KEY'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -27,7 +27,7 @@ class ListUsers
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME')
+                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -23,11 +23,11 @@ class ListUsers
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/admin/users/list/active.json', [
                 'query' => [
                     'order' => 'topics_entered',
-                    'show_emails' => 'true',
+                    'show_emails' => 'true'
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),
-                    'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                    'api-username' => getenv('DISCOURSE_API_USERNAME')
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -22,10 +22,12 @@ class ListUsers
         try {
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/admin/users/list/active.json', [
                 'query' => [
-                    'api_key' => getenv('DISCOURSE_API_KEY'),
-                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
                     'order' => 'topics_entered',
                     'show_emails' => 'true',
+                ],
+                'headers' => [
+                    'api_key' => getenv('DISCOURSE_API_KEY'),
+                    'api_username' => getenv('DISCOURSE_API_USERNAME'),
                 ],
             ]);
 

--- a/src/Action/Discourse/Users/ListUsers.php
+++ b/src/Action/Discourse/Users/ListUsers.php
@@ -23,7 +23,7 @@ class ListUsers
             $response = $client->request('GET', getenv('DISCOURSE_URL') . '/admin/users/list/active.json', [
                 'query' => [
                     'order' => 'topics_entered',
-                    'show_emails' => 'true'
+                    'show_emails' => 'true',
                 ],
                 'headers' => [
                     'api-key' => getenv('DISCOURSE_API_KEY'),

--- a/src/Jobs/Logout.php
+++ b/src/Jobs/Logout.php
@@ -86,7 +86,7 @@ class Logout extends SeatDiscourseJobBase
                 $response = $this->client->request('POST', getenv('DISCOURSE_URL') . '/admin/users/' . $this->discourse_user_id . '/log_out', [
                     'headers' => [
                         'api-key' => getenv('DISCOURSE_API_KEY'),
-                        'api-username' => getenv('DISCOURSE_API_USERNAME')
+                        'api-username' => getenv('DISCOURSE_API_USERNAME'),
                     ],
                 ]);
 
@@ -110,7 +110,7 @@ class Logout extends SeatDiscourseJobBase
         $response = $this->client->request('GET', $uri, [
             'headers' => [
                 'api-key' => getenv('DISCOURSE_API_KEY'),
-                'api-username' => getenv('DISCOURSE_API_USERNAME')
+                'api-username' => getenv('DISCOURSE_API_USERNAME'),
             ],
         ]);
 

--- a/src/Jobs/Logout.php
+++ b/src/Jobs/Logout.php
@@ -86,7 +86,7 @@ class Logout extends SeatDiscourseJobBase
                 $response = $this->client->request('POST', getenv('DISCOURSE_URL') . '/admin/users/' . $this->discourse_user_id . '/log_out', [
                     'headers' => [
                         'api-key' => getenv('DISCOURSE_API_KEY'),
-                        'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                        'api-username' => getenv('DISCOURSE_API_USERNAME')
                     ],
                 ]);
 
@@ -110,7 +110,7 @@ class Logout extends SeatDiscourseJobBase
         $response = $this->client->request('GET', $uri, [
             'headers' => [
                 'api-key' => getenv('DISCOURSE_API_KEY'),
-                'api-username' => getenv('DISCOURSE_API_USERNAME'),
+                'api-username' => getenv('DISCOURSE_API_USERNAME')
             ],
         ]);
 

--- a/src/Jobs/Logout.php
+++ b/src/Jobs/Logout.php
@@ -85,8 +85,8 @@ class Logout extends SeatDiscourseJobBase
             try {
                 $response = $this->client->request('POST', getenv('DISCOURSE_URL') . '/admin/users/' . $this->discourse_user_id . '/log_out', [
                     'headers' => [
-                        'api_key' => getenv('DISCOURSE_API_KEY'),
-                        'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                        'api-key' => getenv('DISCOURSE_API_KEY'),
+                        'api-username' => getenv('DISCOURSE_API_USERNAME'),
                     ],
                 ]);
 
@@ -109,8 +109,8 @@ class Logout extends SeatDiscourseJobBase
 
         $response = $this->client->request('GET', $uri, [
             'headers' => [
-                'api_key' => getenv('DISCOURSE_API_KEY'),
-                'api_username' => getenv('DISCOURSE_API_USERNAME'),
+                'api-key' => getenv('DISCOURSE_API_KEY'),
+                'api-username' => getenv('DISCOURSE_API_USERNAME'),
             ],
         ]);
 

--- a/src/Jobs/Logout.php
+++ b/src/Jobs/Logout.php
@@ -84,7 +84,7 @@ class Logout extends SeatDiscourseJobBase
 
             try {
                 $response = $this->client->request('POST', getenv('DISCOURSE_URL') . '/admin/users/' . $this->discourse_user_id . '/log_out', [
-                    'form_params' => [
+                    'headers' => [
                         'api_key' => getenv('DISCOURSE_API_KEY'),
                         'api_username' => getenv('DISCOURSE_API_USERNAME'),
                     ],
@@ -108,7 +108,7 @@ class Logout extends SeatDiscourseJobBase
         $uri = sprintf('%s/users/by-external/%d.json', getenv('DISCOURSE_URL'), $this->main_character->character_id);
 
         $response = $this->client->request('GET', $uri, [
-            'query' => [
+            'headers' => [
                 'api_key' => getenv('DISCOURSE_API_KEY'),
                 'api_username' => getenv('DISCOURSE_API_USERNAME'),
             ],


### PR DESCRIPTION
This addresses Discourse latest api changes: https://meta.discourse.org/t/discourse-api-documentation/22706/1

> On April 6th, 2020 we dropped support for all non-HTTP header based authentication (excluding some rss, mail-receiver, and ics routes). This means that API requests that have an api_key and api_username in the query params or in the HTTP body of the request will soon stop working. Please see the example cURL request below for how to update your API requests to use the HTTP headers for authentication.